### PR TITLE
fix: update backend Dockerfile to Python 3.11 on Debian bookworm

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,6 +15,9 @@ RUN apt-get update \
  && rm -rf /var/lib/apt/lists/*
 
 # 2) Microsoft ODBC drivers (Debian 12 / bookworm repo)
+# Note: packages.microsoft.com/config/debian/12/prod.list already includes
+# [arch=... signed-by=/usr/share/keyrings/microsoft-prod.gpg] — the sed
+# substitution is not needed and would break the entry if applied.
 RUN curl -fsSL https://packages.microsoft.com/keys/microsoft.asc \
       | gpg --dearmor -o /usr/share/keyrings/microsoft-prod.gpg \
  && curl -fsSL https://packages.microsoft.com/config/debian/12/prod.list \
@@ -38,6 +41,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 WORKDIR /app
 
 # 4) Runtime deps: ODBC runtime + MS drivers
+# Note: packages.microsoft.com/config/debian/12/prod.list already includes
+# [arch=... signed-by=/usr/share/keyrings/microsoft-prod.gpg] — no sed needed.
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
       unixodbc libssl3 \


### PR DESCRIPTION
## What changed

The backend Docker image was broken — `docker compose up` failed to build.

**Root cause 1 — base image drift:** `python:3.9-slim` now resolves to Debian trixie (13). The Dockerfile was bootstrapping the Microsoft ODBC repo using a Debian 10 URL and `apt-key add`, which is deprecated and not available on Debian 13.

**Root cause 2 — Python version mismatch:** CLAUDE.md documents the backend as Python 3.11, but the Dockerfile was pinned to 3.9. The `str | None` union syntax in `connections_routes.py` (PEP 604) requires Python 3.10+, causing an import-time `TypeError` on Python 3.9.

## Changes

- Pin base image to `python:3.11-slim-bookworm` (Debian 12) in both build stages
- Replace deprecated `apt-key add` with `gpg --dearmor` into `/usr/share/keyrings/`
- Switch MS ODBC apt repo URL from Debian 10 to Debian 12 (`packages.microsoft.com/config/debian/12/prod.list`)
- Python 3.9 → 3.11 fixes the `str | None` syntax error at startup

## Security model

No application logic changed. The Fernet key (`CORE_FERNET_KEY`) is loaded from `backend/.env` which is gitignored — it must be created locally before running. This PR does not change that requirement.

## Test plan
- [ ] `docker compose build` completes without error
- [ ] `docker compose up -d` starts both containers healthy
- [ ] `curl http://localhost:8000/ping` returns `{"message":"pong"}`
- [ ] `http://localhost:3000` serves the frontend (setup wizard on first run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)