### PR TITLE
docs: pre-PR self-review checklist and review-response discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,6 +25,7 @@ If format check fails, run `ruff format .` to auto-fix, then re-check.
 - [ ] Any field accepting a bounded set of values uses `Literal[...]`, not bare `str`
 - [ ] Dynamic dict keys that reach a SQL template are allowlisted against a constant before use
 - [ ] No endpoint silently returns 2xx for a no-op where a 4xx is more informative (e.g. PATCH with all-None body, DELETE on already-inactive record)
+- [ ] Multi-step logic that reads DB state then mutates uses pre-flight reads — fetch counts/roles/flags once before any `UPDATE`/`INSERT`/`DELETE` so all guards evaluate the same snapshot
 - [ ] All new endpoints have explicit role checks — authentication ≠ authorisation
 
 ### Responding to review comments


### PR DESCRIPTION
## Summary

PR #73 (user management API) took 3 review rounds for issues that should have been caught before submission, and was merged with an unresolved WARNING and no tracking issue. This PR closes those process gaps.

**Root causes identified:**

1. No self-review step before opening a PR — the pre-PR checklist only covered lint/format, not logic or SQL safety
2. The WARNING handling rule was ambiguous — "fix or track" wasn't clearly enforced as a merge gate

**Changes:**

- Added a **self-review checklist** to the pre-PR section of `CLAUDE.md` covering the specific categories that slipped through:
  - Bracket-quoted SQL identifiers in dynamic templates
  - `Literal[...]` for bounded-value fields (not bare `str`)
  - Allowlist guard before dynamic dict keys reach SQL
  - No silent 2xx for no-ops (empty PATCH body, DELETE on already-inactive)
  - Pre-flight DB reads before any mutations in multi-step logic

- Made the **WARNING/tech-debt tracking rule explicit**: do not merge with an unresolved WARNING unless a GitHub `tech-debt` issue is opened and referenced in the reply first

## Security model

Documentation-only change. No code changes. No new attack surface.

## Tradeoffs

The self-review checklist is backend-focused (SQL patterns). Frontend equivalents will be added if equivalent patterns emerge from future review rounds.