### PR TITLE
fix(#55): 422 on empty PATCH body + tech-debt tracking for remaining review comments

### DIFF
--- a/backend/app/routes/users_routes.py
+++ b/backend/app/routes/users_routes.py
@@ -256,6 +256,9 @@ def update_user(user_id: str, body: UserPatch, user: dict = Depends(verify_token
     schema = config.schema
     now = datetime.now(timezone.utc)
 
+    if body.username is None and body.email is None and body.role is None and body.is_active is None:
+        raise HTTPException(status_code=422, detail="Request body must include at least one field to update")
+
     with engine.begin() as conn:
         existing = conn.execute(
             text(f"""


### PR DESCRIPTION
## Summary

Closes out all untracked review comments from PR #73 — either by fixing them or opening a tracked tech-debt issue.

## What changed

**Fix — empty PATCH body now returns 422**

`PATCH /api/users/{id}` with all-`None` fields was silently returning `{"id": uid}` after two unnecessary DB round-trips. It now raises 422 before opening the transaction. The PR #73 round-3 reviewer flagged this as "worth fixing before this endpoint is wired to a frontend" — the user management UI (#56) is next.

```python
# Before: entered transaction, did nothing, returned 200
# After: fast-fail before touching the DB
if body.username is None and body.email is None and body.role is None and body.is_active is None:
    raise HTTPException(status_code=422, detail="Request body must include at least one field to update")
```

## Tech-debt issues opened

Every unresolved review comment from PR #73 is now tracked:

| Issue | Comment | Decision |
|-------|---------|----------|
| [#84](https://github.com/Luke-Bradford/admin-it/issues/84) | `user_id` path param should use `uuid.UUID` type directly, remove `_parse_user_id` | Tech-debt: low risk refactor |
| [#85](https://github.com/Luke-Bradford/admin-it/issues/85) | `_fetch_role_id` raises `HTTPException` inside a DB transaction — unconventional, untestable | Tech-debt: return `None`, let caller raise |
| [#86](https://github.com/Luke-Bradford/admin-it/issues/86) | `GET /api/users` exposes email — needs documented decision | Tech-debt: document conscious decision; likely keep (internal admin tool) |

## Security model

No change to auth or authorisation. The 422 fires before the token's role is used for any DB operation — the `_require_admin` check has already passed at that point so this doesn't weaken any access control.

## Tradeoffs

Chose to fix the empty-PATCH issue directly rather than open a tech-debt issue, because the reviewer was explicit that it should be resolved before the UI is wired up. The nitpick items (#84, #85) are low-risk refactors better handled together with the user management UI work.