### PR TITLE
fix(#80): escape password as T-SQL literal in CREATE LOGIN DDL

### DIFF
--- a/backend/app/routes/setup_routes.py
+++ b/backend/app/routes/setup_routes.py
@@ -214,11 +214,18 @@ async def create_mssql_db(req: MssqlCreateDbRequest):
                 # SQL Server does not support bind parameters in DDL, so the password
                 # is embedded as a T-SQL string literal.  Single quotes are escaped by
                 # doubling them, which is the standard T-SQL escaping mechanism.
+                # Both the password and the login name are embedded as T-SQL string
+                # literals (SQL Server DDL does not support bind parameters).
+                # Single quotes are escaped by doubling — the only injection vector
+                # in a T-SQL N'...' literal.  _ident() validation on app_login means
+                # it cannot contain single quotes in practice, but we escape anyway
+                # for consistency and defence-in-depth.
                 escaped_pwd = req.app_login_password.replace("'", "''")
+                escaped_login = req.app_login.replace("'", "''")
                 cur.execute(
                     f"""
                     IF NOT EXISTS (
-                        SELECT 1 FROM sys.server_principals WHERE name = N'{req.app_login}'
+                        SELECT 1 FROM sys.server_principals WHERE name = N'{escaped_login}'
                     )
                     CREATE LOGIN {login} WITH PASSWORD = N'{escaped_pwd}'
                     """
@@ -228,16 +235,17 @@ async def create_mssql_db(req: MssqlCreateDbRequest):
         with pyodbc.connect(_cs(req.new_db_name), timeout=10) as db_conn:
             db_conn.autocommit = True
             with db_conn.cursor() as cur:
+                escaped_schema = req.db_schema.replace("'", "''")
                 # Create schema (idempotent)
                 cur.execute(
-                    f"IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = N'{req.db_schema}') "
+                    f"IF NOT EXISTS (SELECT 1 FROM sys.schemas WHERE name = N'{escaped_schema}') "
                     f"EXEC('CREATE SCHEMA {schema}')"
                 )
                 # Create DB user mapped to the login (idempotent)
                 cur.execute(
                     f"""
                     IF NOT EXISTS (
-                        SELECT 1 FROM sys.database_principals WHERE name = N'{req.app_login}'
+                        SELECT 1 FROM sys.database_principals WHERE name = N'{escaped_login}'
                     )
                     CREATE USER {login} FOR LOGIN {login}
                     """


### PR DESCRIPTION
## Summary
- Fixes error 42000/102 `Incorrect syntax near '@P1'` when creating a SQL Server login during setup

## Root cause
SQL Server does not support pyodbc bind parameters (`?`) in DDL statements — only in DML. `CREATE LOGIN ... WITH PASSWORD = ?` is invalid syntax.

## Fix
Single quotes in the password are escaped by doubling them (standard T-SQL string literal escaping), and the password is embedded as `N'...'` directly in the DDL string. This is safe: the only injection vector in a T-SQL string literal is a single quote, and doubling it closes that.

## Security model
- `app_login` is validated by `_ident()` (allowlist: `^[A-Za-z0-9_]+$`) and bracket-quoted — cannot inject
- `app_login_password` has single quotes escaped as `''` before embedding — cannot break out of the string literal context
- Sysadmin credentials are not stored after this request completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)