### PR TITLE
fix(#83): resume setup without auth when schema/admin not yet deployed

### DIFF
--- a/frontend/src/pages/SetupPage.jsx
+++ b/frontend/src/pages/SetupPage.jsx
@@ -1281,6 +1281,7 @@ export default function SetupPage() {
 
   function handleConnectionSaved(conn) {
     setSavedConnection(conn);
+    setInitError(null);
     setStep(2);
   }
 


### PR DESCRIPTION
## Summary

- If the database connection was saved (step 1) but schema deployment failed, the app redirected unauthenticated users to `/login`, which then crashed trying to query `adm.Users` (which didn't exist) — leaving the user locked out with no way back
- Root cause: `determineStep()` checked for a token before checking deploy/admin status, so any partial setup state with no token routed to login
- Fix: check `deploy-status` and `admin-status` **before** the token check. Steps 2 and 3 are first-time setup — the user hasn't created credentials yet, so no auth should be required to reach them
- Auth check is preserved for the fully-configured case (all three steps complete), where a SystemAdmin token is required to re-enter setup
- Added a "← Change connection" link on the step 2 deploy screen so the user can go back to step 1 and fix the connection if deployment fails

## Security model

- Unauthenticated access to setup steps 2 and 3 is gated by the state checks themselves — step 2 is only reachable if `deploy-status` returns `deployed: false`, and step 3 only if `admin-status` returns `present: false`
- The backend endpoints (`/api/setup/deploy-schema`, `/api/setup/create-admin`) already enforce their own guards
- Once fully configured (schema + admin both present), the token requirement is unchanged

## Test plan

- [ ] Partial setup (config saved, schema not deployed): visiting `/setup` should land on step 2 without requiring login
- [ ] Step 2 deploy failure: "← Change connection" link should return to step 1 prefilled with the saved connection
- [ ] Fully configured system: visiting `/setup` without a token should still redirect to login
- [ ] Non-SystemAdmin visiting `/setup` on a fully configured system should redirect to dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)