### PR TITLE
fix(#84): grant REFERENCES on schema to app login during create-mssql-db

### DIFF
--- a/backend/app/routes/setup_routes.py
+++ b/backend/app/routes/setup_routes.py
@@ -251,6 +251,8 @@ async def create_mssql_db(req: MssqlCreateDbRequest):
                 )
                 # Grant least-privilege permissions on the schema
                 cur.execute(f"GRANT SELECT, INSERT, UPDATE, DELETE ON SCHEMA::{schema} TO {login}")
+                # REFERENCES is needed to create foreign keys referencing tables in this schema.
+                cur.execute(f"GRANT REFERENCES ON SCHEMA::{schema} TO {login}")
                 cur.execute(f"GRANT CREATE TABLE TO {login}")
                 cur.execute(f"GRANT ALTER ON SCHEMA::{schema} TO {login}")
 


### PR DESCRIPTION
## Summary

Schema deployment was failing with:
> The REFERENCES permission was denied on the object 'Users', database 'adminit', schema 'adm'. (229)

The `create-mssql-db` endpoint granted `SELECT, INSERT, UPDATE, DELETE`, `CREATE TABLE`, and `ALTER` on the schema — but not `REFERENCES`. The schema deployment script creates tables with foreign keys that reference `[adm].[Users]`, which requires the app login to hold `REFERENCES` on the schema.

Fix: add `GRANT REFERENCES ON SCHEMA::{schema} TO {login}` alongside the existing grants.

## Security model

`REFERENCES` on a schema allows the grantee to create foreign keys referencing objects in that schema. It does not grant read or write access to the data itself. This is a standard least-privilege grant for an app login that owns the schema objects.

## Test plan

- [ ] Run the full setup wizard create-new flow against a fresh SQL Server database — schema deployment should complete without the REFERENCES permission error
- [ ] Verify all tables are created with foreign keys intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)