### PR TITLE
docs(#140): query scheduling implementation plan

### DIFF
--- a/docs/plans/query-scheduling.md
+++ b/docs/plans/query-scheduling.md
@@ -412,6 +412,8 @@ The `Literal[...]` exists separately from `ALLOWED_TOKENS` because Pydantic need
 
 ## Step 3.4 — Pydantic models for schedules
 
+> **Pydantic version note:** this project uses **Pydantic v1** (see `CLAUDE.md` stack notes). The snippets below use v1 syntax: `@root_validator`, `Field(min_items=1)`, etc. Do not pre-emptively migrate to v2 syntax — the project has not migrated and a partial migration would break other models.
+
 **File:** `backend/app/models/schedule.py` (new)
 
 ```python


### PR DESCRIPTION
## Summary

Detailed implementation plan for query scheduling (#140). Builds on the design spec merged in #141.

**This is a docs-only PR.** No code changes.

## Six-PR breakdown

The plan deliberately splits implementation into six bounded PRs rather than one mega-PR. Each is independently reviewable, independently mergeable, and leaves \`main\` in a working state.

| # | Branch prefix | What lands |
|---|---|---|
| 1 | \`refactor/140-extract-query-executor-and-result-export\` | Pure refactor: pull \`query_executor\` and \`result_export\` out of route handlers, consolidate the duplicated \`MAX_EXPORT_ROWS\` constant. No behaviour change. |
| 2 | \`feature/140-smtp-settings\` | SMTP infrastructure, backend + frontend. Admin can configure SMTP and send test emails after merge. |
| 3 | \`feature/140-schedule-crud-and-scheduler\` | Schedule data model, CRUD API, APScheduler bootstrap with single-leader advisory lock, \`/test\` endpoint. Runner is a **stub** in this PR. |
| 4 | \`feature/140-runner-and-execution\` | Real runner, \`/run-now\`, failure notifications, daily housekeeping, orphaned-run cleanup. Cron-fired runs work end-to-end after this PR. |
| 5 | \`feature/140-schedule-frontend\` | Schedule list, create/edit wizard, detail page with run history. |
| 6 | \`docs/140-scheduling-user-guide\` | End-user wiki page. Closes #140. |

## Why six PRs

- A single PR would be ~3,000 lines and unreviewable.
- Each PR adds a complete vertical slice of testable capability.
- Partial merges are valuable: after PR 2, admins can test SMTP. After PR 4, scheduling works via curl. After PR 5, the UI is done.
- Splitting forces reviewers to engage with one concern at a time.

## Order is mandatory

PRs must merge in sequence. PR 4 cannot land without PR 3's tables and bootstrap. PR 5's UI cannot land without PR 4's \`/run-now\` endpoint. The plan explicitly forbids parallel work.

## Conscious tradeoffs flagged in the plan

- **PR 3 ships a runner stub.** The cron firings work end-to-end (the row appears in \`ScheduledQueryRun\`) but no query is executed. Real execution comes in PR 4. This split exists because PR 3 is mostly schema/CRUD plumbing while PR 4 is execution logic — different review surfaces, deserves different reviews.
- **The \`/test\` endpoint in PR 3 duplicates ~30 lines of what PR 4's runner will do.** Necessary so PR 3 is deliverable on its own. PR 4 refactors \`/test\` to call the shared runner.
- **The plan is explicit about what the implementer should not do.** Cross-cutting notes section near the end lists items that should be escalated rather than silently decided (DST/ZoneInfo, APScheduler job persistence, unknown saved-query parameter types, wiki structure).

## Test plan

- [ ] Reviewer reads end to end.
- [ ] Confirm PR breakdown is sensible — flag if a different split would be better.
- [ ] Confirm \"do not\" list (cross-cutting notes) doesn't forbid anything you'd want.
- [ ] Confirm escalation list (open questions for the implementer) covers the right items.
- [ ] Confirm dependency graph is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)