### PR TITLE
refactor(#140): consolidate MAX_EXPORT_ROWS constant

### DIFF
--- a/backend/app/routes/data_routes.py
+++ b/backend/app/routes/data_routes.py
@@ -28,6 +28,7 @@ from pydantic import BaseModel, Field
 from app.routes.browse_routes import TARGET_QUERY_TIMEOUT_SECONDS, _open_target, _require_connection_access
 from app.utils.audit_helpers import log_export_audit, log_masked_access_audit
 from app.utils.auth_dependency import ADMIN_ROLES, verify_token
+from app.utils.constants import MAX_EXPORT_ROWS
 from app.utils.db_helpers import get_backend
 from app.utils.mask_helpers import load_masks
 
@@ -37,9 +38,6 @@ logger = logging.getLogger(__name__)
 # Maximum rows that can be returned in a single page.
 MAX_PAGE_SIZE = 200
 DEFAULT_PAGE_SIZE = 50
-
-# Maximum rows returned by a single export request.
-MAX_EXPORT_ROWS = 10_000
 
 # Supported filter operators and their SQL fragments.
 # Values are always supplied as bind params; column names are bracket-quoted

--- a/backend/app/routes/query_routes.py
+++ b/backend/app/routes/query_routes.py
@@ -36,6 +36,7 @@ from sqlalchemy import text
 from app.routes.browse_routes import TARGET_QUERY_TIMEOUT_SECONDS, _open_target, _require_connection_access
 from app.utils.audit_helpers import log_masked_access_audit, log_query_export_audit, log_query_run_audit
 from app.utils.auth_dependency import ADMIN_ROLES, verify_token
+from app.utils.constants import MAX_EXPORT_ROWS
 from app.utils.db_helpers import get_backend
 from app.utils.mask_helpers import load_masks_for_connection
 from app.utils.sql_helpers import quote_ident as qi
@@ -45,7 +46,6 @@ logger = logging.getLogger(__name__)
 
 POWER_AND_ABOVE: set[str] = {"PowerUser", "Admin", "SystemAdmin"}
 MAX_PAGE_SIZE = 200
-MAX_EXPORT_ROWS = 10_000
 
 # Regex for `:name` placeholder extraction and rewrite.
 # Negative lookahead prevents partial matches (e.g. :user_id must not match inside :user_id_ext).

--- a/backend/app/utils/constants.py
+++ b/backend/app/utils/constants.py
@@ -1,0 +1,13 @@
+"""Centralised constants used across routes and (future) scheduler.
+
+Single source of truth for limits, caps, and tunables that would otherwise
+be duplicated across modules. New constants land here when they need to be
+referenced from more than one place.
+"""
+
+# Maximum rows returned by a single export request (CSV / XLSX) and by a
+# single scheduled-run delivery. Was previously duplicated in
+# data_routes.py and query_routes.py; consolidated here so changing it
+# (or referencing it from the future scheduler runner) only touches one
+# location.
+MAX_EXPORT_ROWS = 10_000


### PR DESCRIPTION
## Summary
- New `backend/app/utils/constants.py` holds `MAX_EXPORT_ROWS = 10_000` as the single source of truth.
- `data_routes.py` and `query_routes.py` now import it instead of redeclaring the literal.
- Prep work for the query scheduler (#19) so the runner can reference the same cap without re-duplicating.

## Plan deviation (intentional)
PR 1 in [docs/plans/query-scheduling.md](docs/plans/query-scheduling.md) originally bundled this with extractions of `result_export.py` and `query_executor.py` helpers. **The backend has zero tests today**, so a wider refactor has no regression net — the risk/value ratio is wrong for a "prep" PR. Scoping PR 1 down to constants-only; the helper extractions are deferred to PR 4 where scheduler-side code will actually exercise them, and any behaviour drift will be caught by the new runner tests landing alongside.

## Security model
No behaviour change. Both call sites already enforce auth + connection access; the cap value is identical (10,000).

## Test plan
- [x] `ruff check .` — passes
- [x] `ruff format --check .` — passes
- [ ] Manual: export from data browser still caps at 10k
- [ ] Manual: export from saved query still caps at 10k

🤖 Generated with [Claude Code](https://claude.com/claude-code)