### PR TITLE
feat(#140): SMTP settings + test email infrastructure

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -18,6 +18,7 @@ from app.routes.discovery_routes import router as discovery_router
 from app.routes.manage_routes import router as manage_router
 from app.routes.masks_routes import router as masks_router
 from app.routes.query_routes import router as query_router
+from app.routes.settings_routes import router as settings_router
 from app.routes.setup_routes import router as setup_router
 from app.routes.users_routes import router as users_router
 from app.utils.db_helpers import init_engine
@@ -146,3 +147,4 @@ app.include_router(masks_router, prefix="/api/connections", tags=["Masks"])
 app.include_router(users_router, prefix="/api/users", tags=["Users"])
 app.include_router(query_router, prefix="/api/queries", tags=["Queries"])
 app.include_router(audit_router, prefix="/api/audit", tags=["Audit"])
+app.include_router(settings_router, prefix="/api/settings", tags=["Settings"])

--- a/backend/app/routes/settings_routes.py
+++ b/backend/app/routes/settings_routes.py
@@ -187,19 +187,18 @@ def _password_row_exists_in_conn(conn, schema: str, db_type: str) -> bool:
     return row is not None
 
 
-def _load_password(backend) -> str | None:
+def _load_password_in_conn(conn, backend, schema: str, db_type: str) -> str | None:
     """Return the decrypted SMTP password, or None if no row exists.
 
-    Mirrors `_password_row_exists`: only row-absence yields None. Any
-    decrypt failure propagates as HTTPException(500) via decrypt_value.
+    Mirrors `_password_row_exists_in_conn`: takes the conn so callers can
+    keep the read in the same transaction as the settings read. Only
+    row-absence yields None; any decrypt failure propagates as
+    HTTPException(500) via `decrypt_value`.
     """
-    engine = backend.get_engine()
-    table = qi(backend.schema, "Secrets", backend.db_type)
-    with engine.connect() as conn:
-        row = conn.execute(
-            text(f'SELECT "SecretValue" FROM {table} WHERE "SecretType" = :st'),
-            {"st": SMTP_PASSWORD_SECRET},
-        ).fetchone()
+    row = conn.execute(
+        text(f'SELECT "SecretValue" FROM {qi(schema, "Secrets", db_type)} WHERE "SecretType" = :st'),
+        {"st": SMTP_PASSWORD_SECRET},
+    ).fetchone()
     if row is None:
         return None
     return decrypt_value(backend, row[0])
@@ -346,8 +345,13 @@ def send_smtp_test(body: SmtpTestRequest, user: dict = Depends(verify_token)) ->
     _require_admin(user)
     backend = get_backend()
     engine = backend.get_engine()
+    schema = backend.schema
+    db_type = backend.db_type
+    # Read settings + password in a single connection so a concurrent
+    # PUT /smtp/password cannot commit between the two reads.
     with engine.connect() as conn:
-        stored = _read_smtp_settings_rows(conn, backend.schema, backend.db_type)
+        stored = _read_smtp_settings_rows(conn, schema, db_type)
+        password = _load_password_in_conn(conn, backend, schema, db_type)
 
     host = stored.get("host")
     port = stored.get("port")
@@ -362,11 +366,7 @@ def send_smtp_test(body: SmtpTestRequest, user: dict = Depends(verify_token)) ->
             "error": "SMTP is not fully configured. Save host, port, TLS mode, and from address first.",
         }
 
-    verify_ssl = stored.get("verify_ssl")
-    if verify_ssl is None:
-        verify_ssl = True
-
-    password = _load_password(backend)
+    verify_ssl = stored.get("verify_ssl", True)
     try:
         send_email(
             host=host,

--- a/backend/app/routes/settings_routes.py
+++ b/backend/app/routes/settings_routes.py
@@ -1,0 +1,339 @@
+# app/routes/settings_routes.py
+#
+# SMTP configuration routes (admin-only). The SMTP password is encrypted with
+# the existing CONNECTION_KEY Fernet key and stored in [adm].[Secrets] under
+# SecretType = 'SMTP_PASSWORD'. All other SMTP fields are JSON-encoded into
+# rows in [adm].[Settings] keyed 'smtp.host', 'smtp.port', etc.
+#
+# The Settings table is generic key/value — keys are tightly allowlisted at
+# the route layer, never derived from user input.
+
+import json
+import logging
+import re
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Literal
+
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, Field, field_validator
+from sqlalchemy import bindparam, text
+
+from app.utils.auth_dependency import ADMIN_ROLES, verify_token
+from app.utils.connection_crypto import decrypt_value, encrypt_value
+from app.utils.db_helpers import get_backend
+from app.utils.email_sender import EmailSendError, send_email
+from app.utils.sql_helpers import quote_ident as qi
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+TlsMode = Literal["none", "starttls", "tls"]
+
+# Allowlist of Settings keys this router is allowed to read/write. Used to
+# defend against any future code path that might pass a key derived from
+# user input — every key reaching the SQL template must be in this set.
+SMTP_SETTING_KEYS: tuple[str, ...] = (
+    "smtp.host",
+    "smtp.port",
+    "smtp.tls_mode",
+    "smtp.username",
+    "smtp.from_address",
+    "smtp.from_name",
+    "smtp.reply_to_address",
+    "smtp.allowlist_enabled",
+    "smtp.allowed_domains",
+)
+
+SMTP_PASSWORD_SECRET = "SMTP_PASSWORD"
+
+# Lightweight email syntax check — full RFC 5322 is overkill and we don't have
+# email-validator installed. The SMTP server is the real source of truth.
+_EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
+
+
+def _validate_email(value: str) -> str:
+    if not _EMAIL_RE.match(value):
+        raise ValueError("Invalid email address")
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Models
+# ---------------------------------------------------------------------------
+
+
+class SmtpSettingsOut(BaseModel):
+    host: str | None
+    port: int | None
+    tls_mode: TlsMode | None
+    username: str | None
+    from_address: str | None
+    from_name: str | None
+    reply_to_address: str | None
+    allowlist_enabled: bool
+    allowed_domains: list[str]
+    password_set: bool
+
+
+class SmtpSettingsUpdate(BaseModel):
+    host: str = Field(min_length=1, max_length=255)
+    port: int = Field(ge=1, le=65535)
+    tls_mode: TlsMode
+    username: str | None = Field(default=None, max_length=255)
+    from_address: str = Field(min_length=3, max_length=320)
+    from_name: str | None = Field(default=None, max_length=255)
+    reply_to_address: str | None = Field(default=None, max_length=320)
+    allowlist_enabled: bool = False
+    allowed_domains: list[str] = Field(default_factory=list)
+
+    @field_validator("from_address")
+    @classmethod
+    def _check_from(cls, v: str) -> str:
+        return _validate_email(v)
+
+    @field_validator("reply_to_address")
+    @classmethod
+    def _check_reply_to(cls, v: str | None) -> str | None:
+        return _validate_email(v) if v else v
+
+    @field_validator("allowed_domains")
+    @classmethod
+    def _check_domains(cls, v: list[str]) -> list[str]:
+        cleaned: list[str] = []
+        for d in v:
+            d = d.strip().lower()
+            if not d:
+                continue
+            if not re.match(r"^[a-z0-9.-]+\.[a-z]{2,}$", d):
+                raise ValueError(f"Invalid domain: {d}")
+            cleaned.append(d)
+        return cleaned
+
+
+class SmtpPasswordUpdate(BaseModel):
+    password: str = Field(min_length=1, max_length=500)
+
+
+class SmtpTestRequest(BaseModel):
+    to: str = Field(min_length=3, max_length=320)
+
+    @field_validator("to")
+    @classmethod
+    def _check_to(cls, v: str) -> str:
+        return _validate_email(v)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _require_admin(user: dict) -> None:
+    if not ADMIN_ROLES.intersection(user.get("roles", [])):
+        raise HTTPException(status_code=403, detail="Admin role required")
+
+
+def _read_smtp_settings_rows(conn, schema: str, db_type: str) -> dict[str, Any]:
+    """Read all SMTP settings rows in one query and decode their JSON values.
+
+    Returns a dict keyed by short field name (e.g. 'host', 'port').
+    """
+    stmt = text(f"""
+        SELECT "SettingKey", "SettingValue"
+        FROM {qi(schema, "Settings", db_type)}
+        WHERE "SettingKey" IN :keys
+    """).bindparams(bindparam("keys", expanding=True))
+    rows = conn.execute(stmt, {"keys": list(SMTP_SETTING_KEYS)}).fetchall()
+    out: dict[str, Any] = {}
+    for key, raw in rows:
+        if key not in SMTP_SETTING_KEYS:
+            continue
+        short = key.removeprefix("smtp.")
+        try:
+            out[short] = json.loads(raw)
+        except (TypeError, ValueError):
+            logger.warning("[settings] Could not JSON-decode %s", key)
+            out[short] = None
+    return out
+
+
+def _password_is_set(backend) -> bool:
+    try:
+        backend.fetch_secret(SMTP_PASSWORD_SECRET)
+        return True
+    except RuntimeError:
+        return False
+
+
+def _load_password(backend) -> str | None:
+    try:
+        token = backend.fetch_secret(SMTP_PASSWORD_SECRET)
+    except RuntimeError:
+        return None
+    return decrypt_value(backend, token)
+
+
+def _upsert_setting(conn, schema: str, db_type: str, key: str, value: Any, user_id: str, now: datetime) -> None:
+    """Upsert a single Settings row. Key MUST be in SMTP_SETTING_KEYS."""
+    if key not in SMTP_SETTING_KEYS:
+        # Defensive — should be impossible since callers iterate the constant.
+        raise HTTPException(status_code=500, detail="Internal error: unknown setting key")
+    encoded = json.dumps(value)
+    table = qi(schema, "Settings", db_type)
+    if db_type == "mssql":
+        sql = f"""
+            MERGE {table} AS target
+            USING (SELECT :k AS k) AS src ON target."SettingKey" = src.k
+            WHEN MATCHED THEN UPDATE SET
+                "SettingValue" = :v, "UpdatedAt" = :now, "UpdatedBy" = :uid
+            WHEN NOT MATCHED THEN
+                INSERT ("SettingKey", "SettingValue", "UpdatedAt", "UpdatedBy")
+                VALUES (:k, :v, :now, :uid);
+        """
+    else:
+        sql = f"""
+            INSERT INTO {table} ("SettingKey", "SettingValue", "UpdatedAt", "UpdatedBy")
+            VALUES (:k, :v, :now, :uid)
+            ON CONFLICT ("SettingKey") DO UPDATE SET
+                "SettingValue" = EXCLUDED."SettingValue",
+                "UpdatedAt" = EXCLUDED."UpdatedAt",
+                "UpdatedBy" = EXCLUDED."UpdatedBy";
+        """
+    conn.execute(text(sql), {"k": key, "v": encoded, "now": now, "uid": user_id})
+
+
+def _upsert_secret(conn, schema: str, db_type: str, secret_type: str, secret_value: str) -> None:
+    """Upsert a row in [adm].[Secrets] keyed by SecretType."""
+    table = qi(schema, "Secrets", db_type)
+    existing = conn.execute(
+        text(f'SELECT 1 FROM {table} WHERE "SecretType" = :st'),
+        {"st": secret_type},
+    ).fetchone()
+    if existing:
+        conn.execute(
+            text(f'UPDATE {table} SET "SecretValue" = :v WHERE "SecretType" = :st'),
+            {"v": secret_value, "st": secret_type},
+        )
+    else:
+        conn.execute(
+            text(f"""
+                INSERT INTO {table} ("SecretId", "SecretType", "SecretDescription", "SecretValue")
+                VALUES (:id, :st, :desc, :v)
+            """),
+            {
+                "id": str(uuid.uuid4()),
+                "st": secret_type,
+                "desc": "SMTP outbound password (Fernet-encrypted with CONNECTION_KEY)",
+                "v": secret_value,
+            },
+        )
+
+
+def _build_settings_out(stored: dict[str, Any], password_set: bool) -> SmtpSettingsOut:
+    return SmtpSettingsOut(
+        host=stored.get("host"),
+        port=stored.get("port"),
+        tls_mode=stored.get("tls_mode"),
+        username=stored.get("username"),
+        from_address=stored.get("from_address"),
+        from_name=stored.get("from_name"),
+        reply_to_address=stored.get("reply_to_address"),
+        allowlist_enabled=bool(stored.get("allowlist_enabled") or False),
+        allowed_domains=list(stored.get("allowed_domains") or []),
+        password_set=password_set,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Routes
+# ---------------------------------------------------------------------------
+
+
+@router.get("/smtp", response_model=SmtpSettingsOut)
+def get_smtp_settings(user: dict = Depends(verify_token)) -> SmtpSettingsOut:
+    _require_admin(user)
+    backend = get_backend()
+    engine = backend.get_engine()
+    with engine.connect() as conn:
+        stored = _read_smtp_settings_rows(conn, backend.schema, backend.db_type)
+    return _build_settings_out(stored, _password_is_set(backend))
+
+
+@router.put("/smtp", response_model=SmtpSettingsOut)
+def update_smtp_settings(body: SmtpSettingsUpdate, user: dict = Depends(verify_token)) -> SmtpSettingsOut:
+    _require_admin(user)
+    backend = get_backend()
+    engine = backend.get_engine()
+    schema = backend.schema
+    db_type = backend.db_type
+    now = datetime.now(timezone.utc)
+
+    field_to_value: dict[str, Any] = {
+        "smtp.host": body.host,
+        "smtp.port": body.port,
+        "smtp.tls_mode": body.tls_mode,
+        "smtp.username": body.username,
+        "smtp.from_address": body.from_address,
+        "smtp.from_name": body.from_name,
+        "smtp.reply_to_address": body.reply_to_address,
+        "smtp.allowlist_enabled": body.allowlist_enabled,
+        "smtp.allowed_domains": body.allowed_domains,
+    }
+
+    with engine.begin() as conn:
+        for key, value in field_to_value.items():
+            _upsert_setting(conn, schema, db_type, key, value, user["user_id"], now)
+        stored = _read_smtp_settings_rows(conn, schema, db_type)
+
+    return _build_settings_out(stored, _password_is_set(backend))
+
+
+@router.put("/smtp/password", status_code=204)
+def update_smtp_password(body: SmtpPasswordUpdate, user: dict = Depends(verify_token)) -> None:
+    _require_admin(user)
+    backend = get_backend()
+    engine = backend.get_engine()
+    encrypted = encrypt_value(backend, body.password)
+    with engine.begin() as conn:
+        _upsert_secret(conn, backend.schema, backend.db_type, SMTP_PASSWORD_SECRET, encrypted)
+    return None
+
+
+@router.post("/smtp/test")
+def send_smtp_test(body: SmtpTestRequest, user: dict = Depends(verify_token)) -> dict:
+    _require_admin(user)
+    backend = get_backend()
+    engine = backend.get_engine()
+    with engine.connect() as conn:
+        stored = _read_smtp_settings_rows(conn, backend.schema, backend.db_type)
+
+    host = stored.get("host")
+    port = stored.get("port")
+    tls_mode = stored.get("tls_mode")
+    from_address = stored.get("from_address")
+    if not host or not port or not tls_mode or not from_address:
+        raise HTTPException(
+            status_code=400,
+            detail="SMTP is not fully configured. Save host, port, TLS mode, and from address first.",
+        )
+
+    password = _load_password(backend)
+    try:
+        send_email(
+            host=host,
+            port=int(port),
+            tls_mode=tls_mode,
+            username=stored.get("username"),
+            password=password,
+            from_address=from_address,
+            from_name=stored.get("from_name"),
+            reply_to=stored.get("reply_to_address"),
+            to=[body.to],
+            subject="admin-it SMTP test message",
+            body=("This is a test message from admin-it.\n\nIf you received this, your SMTP configuration is working."),
+        )
+    except EmailSendError as e:
+        return {"ok": False, "error": str(e)}
+
+    return {"ok": True}

--- a/backend/app/routes/settings_routes.py
+++ b/backend/app/routes/settings_routes.py
@@ -287,6 +287,8 @@ def _build_settings_out(stored: dict[str, Any], password_set: bool) -> SmtpSetti
         reply_to_address=stored.get("reply_to_address"),
         allowlist_enabled=bool(stored.get("allowlist_enabled") or False),
         allowed_domains=list(stored.get("allowed_domains") or []),
+        # Any non-False stored value (including missing or JSON-corrupt) → True;
+        # only an explicit False disables verification.
         verify_ssl=stored.get("verify_ssl", True) is not False,
         password_set=password_set,
     )

--- a/backend/app/routes/settings_routes.py
+++ b/backend/app/routes/settings_routes.py
@@ -164,23 +164,26 @@ def _read_smtp_settings_rows(conn, schema: str, db_type: str) -> dict[str, Any]:
     return out
 
 
-def _password_row_exists(backend) -> bool:
+def _password_row_exists_in_conn(conn, schema: str, db_type: str) -> bool:
     """Return True iff a row keyed SMTP_PASSWORD exists in [adm].[Secrets].
 
-    Uses a direct SELECT — does NOT call `fetch_secret`, because that helper
-    raises a generic `RuntimeError` for not-found and would force us to
-    swallow ALL RuntimeErrors here. We only want to treat row-absence as
-    'not set'; any other error (DB down, permission denied) must propagate
-    so the admin sees a real error rather than being told 'no password set'
-    and overwriting a still-encrypted secret.
+    Uses a direct SELECT on the supplied connection — does NOT call
+    `fetch_secret`, because that helper raises a generic `RuntimeError` for
+    not-found and would force us to swallow ALL RuntimeErrors here. We only
+    want to treat row-absence as 'not set'; any other error (DB down,
+    permission denied) must propagate so the admin sees a real error rather
+    than being told 'no password set' and overwriting a still-encrypted
+    secret.
+
+    Takes the conn as a parameter so callers can include this check in the
+    same transaction as their settings reads/writes — otherwise a concurrent
+    `PUT /smtp/password` could commit between the two connections and the
+    response would show a stale `password_set` value.
     """
-    engine = backend.get_engine()
-    table = qi(backend.schema, "Secrets", backend.db_type)
-    with engine.connect() as conn:
-        row = conn.execute(
-            text(f'SELECT 1 FROM {table} WHERE "SecretType" = :st'),
-            {"st": SMTP_PASSWORD_SECRET},
-        ).fetchone()
+    row = conn.execute(
+        text(f'SELECT 1 FROM {qi(schema, "Secrets", db_type)} WHERE "SecretType" = :st'),
+        {"st": SMTP_PASSWORD_SECRET},
+    ).fetchone()
     return row is not None
 
 
@@ -292,7 +295,8 @@ def get_smtp_settings(user: dict = Depends(verify_token)) -> SmtpSettingsOut:
     engine = backend.get_engine()
     with engine.connect() as conn:
         stored = _read_smtp_settings_rows(conn, backend.schema, backend.db_type)
-    return _build_settings_out(stored, _password_row_exists(backend))
+        password_set = _password_row_exists_in_conn(conn, backend.schema, backend.db_type)
+    return _build_settings_out(stored, password_set)
 
 
 @router.put("/smtp", response_model=SmtpSettingsOut)
@@ -321,8 +325,9 @@ def update_smtp_settings(body: SmtpSettingsUpdate, user: dict = Depends(verify_t
         for key, value in field_to_value.items():
             _upsert_setting(conn, schema, db_type, key, value, user["user_id"], now)
         stored = _read_smtp_settings_rows(conn, schema, db_type)
+        password_set = _password_row_exists_in_conn(conn, schema, db_type)
 
-    return _build_settings_out(stored, _password_row_exists(backend))
+    return _build_settings_out(stored, password_set)
 
 
 @router.put("/smtp/password", status_code=204)

--- a/backend/app/routes/settings_routes.py
+++ b/backend/app/routes/settings_routes.py
@@ -33,6 +33,9 @@ TlsMode = Literal["none", "starttls", "tls"]
 # Allowlist of Settings keys this router is allowed to read/write. Used to
 # defend against any future code path that might pass a key derived from
 # user input — every key reaching the SQL template must be in this set.
+# Note: this list is small (10 items) and bounded. SQLAlchemy's expanding
+# bindparam generates `IN (:k_1, :k_2, ...)` which is fine on MSSQL up to its
+# 2,100-parameter limit — well above any plausible growth here.
 SMTP_SETTING_KEYS: tuple[str, ...] = (
     "smtp.host",
     "smtp.port",
@@ -43,6 +46,7 @@ SMTP_SETTING_KEYS: tuple[str, ...] = (
     "smtp.reply_to_address",
     "smtp.allowlist_enabled",
     "smtp.allowed_domains",
+    "smtp.verify_ssl",
 )
 
 SMTP_PASSWORD_SECRET = "SMTP_PASSWORD"
@@ -73,6 +77,7 @@ class SmtpSettingsOut(BaseModel):
     reply_to_address: str | None
     allowlist_enabled: bool
     allowed_domains: list[str]
+    verify_ssl: bool
     password_set: bool
 
 
@@ -86,6 +91,7 @@ class SmtpSettingsUpdate(BaseModel):
     reply_to_address: str | None = Field(default=None, max_length=320)
     allowlist_enabled: bool = False
     allowed_domains: list[str] = Field(default_factory=list)
+    verify_ssl: bool = True
 
     @field_validator("from_address")
     @classmethod
@@ -158,20 +164,42 @@ def _read_smtp_settings_rows(conn, schema: str, db_type: str) -> dict[str, Any]:
     return out
 
 
-def _password_is_set(backend) -> bool:
-    try:
-        backend.fetch_secret(SMTP_PASSWORD_SECRET)
-        return True
-    except RuntimeError:
-        return False
+def _password_row_exists(backend) -> bool:
+    """Return True iff a row keyed SMTP_PASSWORD exists in [adm].[Secrets].
+
+    Uses a direct SELECT — does NOT call `fetch_secret`, because that helper
+    raises a generic `RuntimeError` for not-found and would force us to
+    swallow ALL RuntimeErrors here. We only want to treat row-absence as
+    'not set'; any other error (DB down, permission denied) must propagate
+    so the admin sees a real error rather than being told 'no password set'
+    and overwriting a still-encrypted secret.
+    """
+    engine = backend.get_engine()
+    table = qi(backend.schema, "Secrets", backend.db_type)
+    with engine.connect() as conn:
+        row = conn.execute(
+            text(f'SELECT 1 FROM {table} WHERE "SecretType" = :st'),
+            {"st": SMTP_PASSWORD_SECRET},
+        ).fetchone()
+    return row is not None
 
 
 def _load_password(backend) -> str | None:
-    try:
-        token = backend.fetch_secret(SMTP_PASSWORD_SECRET)
-    except RuntimeError:
+    """Return the decrypted SMTP password, or None if no row exists.
+
+    Mirrors `_password_row_exists`: only row-absence yields None. Any
+    decrypt failure propagates as HTTPException(500) via decrypt_value.
+    """
+    engine = backend.get_engine()
+    table = qi(backend.schema, "Secrets", backend.db_type)
+    with engine.connect() as conn:
+        row = conn.execute(
+            text(f'SELECT "SecretValue" FROM {table} WHERE "SecretType" = :st'),
+            {"st": SMTP_PASSWORD_SECRET},
+        ).fetchone()
+    if row is None:
         return None
-    return decrypt_value(backend, token)
+    return decrypt_value(backend, row[0])
 
 
 def _upsert_setting(conn, schema: str, db_type: str, key: str, value: Any, user_id: str, now: datetime) -> None:
@@ -183,7 +211,7 @@ def _upsert_setting(conn, schema: str, db_type: str, key: str, value: Any, user_
     table = qi(schema, "Settings", db_type)
     if db_type == "mssql":
         sql = f"""
-            MERGE {table} AS target
+            MERGE {table} WITH (HOLDLOCK) AS target
             USING (SELECT :k AS k) AS src ON target."SettingKey" = src.k
             WHEN MATCHED THEN UPDATE SET
                 "SettingValue" = :v, "UpdatedAt" = :now, "UpdatedBy" = :uid
@@ -204,30 +232,36 @@ def _upsert_setting(conn, schema: str, db_type: str, key: str, value: Any, user_
 
 
 def _upsert_secret(conn, schema: str, db_type: str, secret_type: str, secret_value: str) -> None:
-    """Upsert a row in [adm].[Secrets] keyed by SecretType."""
+    """Atomically upsert a row in [adm].[Secrets] keyed by SecretType.
+
+    Uses MERGE / ON CONFLICT to avoid a TOCTOU race between two concurrent
+    password updates (which with a separate SELECT-then-INSERT would both
+    see no row and both INSERT, causing a primary-key violation).
+    """
     table = qi(schema, "Secrets", db_type)
-    existing = conn.execute(
-        text(f'SELECT 1 FROM {table} WHERE "SecretType" = :st'),
-        {"st": secret_type},
-    ).fetchone()
-    if existing:
-        conn.execute(
-            text(f'UPDATE {table} SET "SecretValue" = :v WHERE "SecretType" = :st'),
-            {"v": secret_value, "st": secret_type},
-        )
+    desc = "SMTP outbound password (Fernet-encrypted with CONNECTION_KEY)"
+    new_id = str(uuid.uuid4())
+    if db_type == "mssql":
+        sql = f"""
+            MERGE {table} WITH (HOLDLOCK) AS target
+            USING (SELECT :st AS st) AS src ON target."SecretType" = src.st
+            WHEN MATCHED THEN UPDATE SET
+                "SecretValue" = :v
+            WHEN NOT MATCHED THEN
+                INSERT ("SecretId", "SecretType", "SecretDescription", "SecretValue")
+                VALUES (:id, :st, :desc, :v);
+        """
     else:
-        conn.execute(
-            text(f"""
-                INSERT INTO {table} ("SecretId", "SecretType", "SecretDescription", "SecretValue")
-                VALUES (:id, :st, :desc, :v)
-            """),
-            {
-                "id": str(uuid.uuid4()),
-                "st": secret_type,
-                "desc": "SMTP outbound password (Fernet-encrypted with CONNECTION_KEY)",
-                "v": secret_value,
-            },
-        )
+        sql = f"""
+            INSERT INTO {table} ("SecretId", "SecretType", "SecretDescription", "SecretValue")
+            VALUES (:id, :st, :desc, :v)
+            ON CONFLICT ("SecretType") DO UPDATE SET
+                "SecretValue" = EXCLUDED."SecretValue";
+        """
+    conn.execute(
+        text(sql),
+        {"id": new_id, "st": secret_type, "desc": desc, "v": secret_value},
+    )
 
 
 def _build_settings_out(stored: dict[str, Any], password_set: bool) -> SmtpSettingsOut:
@@ -241,6 +275,7 @@ def _build_settings_out(stored: dict[str, Any], password_set: bool) -> SmtpSetti
         reply_to_address=stored.get("reply_to_address"),
         allowlist_enabled=bool(stored.get("allowlist_enabled") or False),
         allowed_domains=list(stored.get("allowed_domains") or []),
+        verify_ssl=bool(stored.get("verify_ssl") if stored.get("verify_ssl") is not None else True),
         password_set=password_set,
     )
 
@@ -257,7 +292,7 @@ def get_smtp_settings(user: dict = Depends(verify_token)) -> SmtpSettingsOut:
     engine = backend.get_engine()
     with engine.connect() as conn:
         stored = _read_smtp_settings_rows(conn, backend.schema, backend.db_type)
-    return _build_settings_out(stored, _password_is_set(backend))
+    return _build_settings_out(stored, _password_row_exists(backend))
 
 
 @router.put("/smtp", response_model=SmtpSettingsOut)
@@ -279,6 +314,7 @@ def update_smtp_settings(body: SmtpSettingsUpdate, user: dict = Depends(verify_t
         "smtp.reply_to_address": body.reply_to_address,
         "smtp.allowlist_enabled": body.allowlist_enabled,
         "smtp.allowed_domains": body.allowed_domains,
+        "smtp.verify_ssl": body.verify_ssl,
     }
 
     with engine.begin() as conn:
@@ -286,7 +322,7 @@ def update_smtp_settings(body: SmtpSettingsUpdate, user: dict = Depends(verify_t
             _upsert_setting(conn, schema, db_type, key, value, user["user_id"], now)
         stored = _read_smtp_settings_rows(conn, schema, db_type)
 
-    return _build_settings_out(stored, _password_is_set(backend))
+    return _build_settings_out(stored, _password_row_exists(backend))
 
 
 @router.put("/smtp/password", status_code=204)
@@ -313,10 +349,17 @@ def send_smtp_test(body: SmtpTestRequest, user: dict = Depends(verify_token)) ->
     tls_mode = stored.get("tls_mode")
     from_address = stored.get("from_address")
     if not host or not port or not tls_mode or not from_address:
-        raise HTTPException(
-            status_code=400,
-            detail="SMTP is not fully configured. Save host, port, TLS mode, and from address first.",
-        )
+        # Return 200 with ok=False so the UI handles "incomplete config" the
+        # same way it handles a real send failure (consistent contract — see
+        # PR description and the EmailSendError branch below).
+        return {
+            "ok": False,
+            "error": "SMTP is not fully configured. Save host, port, TLS mode, and from address first.",
+        }
+
+    verify_ssl = stored.get("verify_ssl")
+    if verify_ssl is None:
+        verify_ssl = True
 
     password = _load_password(backend)
     try:
@@ -330,6 +373,7 @@ def send_smtp_test(body: SmtpTestRequest, user: dict = Depends(verify_token)) ->
             from_name=stored.get("from_name"),
             reply_to=stored.get("reply_to_address"),
             to=[body.to],
+            verify_ssl=bool(verify_ssl),
             subject="admin-it SMTP test message",
             body=("This is a test message from admin-it.\n\nIf you received this, your SMTP configuration is working."),
         )

--- a/backend/app/routes/settings_routes.py
+++ b/backend/app/routes/settings_routes.py
@@ -120,6 +120,16 @@ class SmtpSettingsUpdate(BaseModel):
 class SmtpPasswordUpdate(BaseModel):
     password: str = Field(min_length=1, max_length=500)
 
+    @field_validator("password")
+    @classmethod
+    def _check_password(cls, v: str) -> str:
+        # A password of pure whitespace is almost certainly a paste error and
+        # would silently break the next outbound send. Reject it at the
+        # boundary rather than encrypting and storing it.
+        if not v.strip():
+            raise ValueError("Password must not be empty or whitespace-only")
+        return v
+
 
 class SmtpTestRequest(BaseModel):
     to: str = Field(min_length=3, max_length=320)
@@ -277,7 +287,7 @@ def _build_settings_out(stored: dict[str, Any], password_set: bool) -> SmtpSetti
         reply_to_address=stored.get("reply_to_address"),
         allowlist_enabled=bool(stored.get("allowlist_enabled") or False),
         allowed_domains=list(stored.get("allowed_domains") or []),
-        verify_ssl=bool(stored.get("verify_ssl") if stored.get("verify_ssl") is not None else True),
+        verify_ssl=stored.get("verify_ssl", True) is not False,
         password_set=password_set,
     )
 
@@ -366,7 +376,10 @@ def send_smtp_test(body: SmtpTestRequest, user: dict = Depends(verify_token)) ->
             "error": "SMTP is not fully configured. Save host, port, TLS mode, and from address first.",
         }
 
-    verify_ssl = stored.get("verify_ssl", True)
+    # Default to True (verify) for both missing and any decode-corrupted
+    # value. Never let an unexpected None silently disable verification.
+    verify_ssl_raw = stored.get("verify_ssl", True)
+    verify_ssl = verify_ssl_raw is not False
     try:
         send_email(
             host=host,
@@ -378,7 +391,7 @@ def send_smtp_test(body: SmtpTestRequest, user: dict = Depends(verify_token)) ->
             from_name=stored.get("from_name"),
             reply_to=stored.get("reply_to_address"),
             to=[body.to],
-            verify_ssl=bool(verify_ssl),
+            verify_ssl=verify_ssl,
             subject="admin-it SMTP test message",
             body=("This is a test message from admin-it.\n\nIf you received this, your SMTP configuration is working."),
         )

--- a/backend/app/sql/deploy_core_schema_postgres.sql
+++ b/backend/app/sql/deploy_core_schema_postgres.sql
@@ -199,6 +199,19 @@ CREATE TABLE IF NOT EXISTS "__SCHEMA__"."audit_log" (
 );
 
 -- ──────────────────────────────────────────────
+-- SETTINGS
+-- Generic key/value table for application settings (e.g. SMTP config).
+-- Values are JSON-encoded text. Mutable in place; audit at the route layer.
+-- ──────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS "__SCHEMA__"."Settings" (
+    "SettingKey"   VARCHAR(100) NOT NULL PRIMARY KEY,
+    "SettingValue" TEXT         NOT NULL,
+    "UpdatedAt"    TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    "UpdatedBy"    UUID
+);
+
+-- ──────────────────────────────────────────────
 -- AUDIT TRIGGER FUNCTION
 -- Shared by all audited tables.
 -- Uses current_setting('app.current_user_id', true) to get the caller's

--- a/backend/app/sql/spDeployCoreSchema.sql
+++ b/backend/app/sql/spDeployCoreSchema.sql
@@ -276,10 +276,10 @@ IF NOT EXISTS (SELECT 1 FROM sys.tables t
                WHERE s.name = ''' + @SchemaName + ''' AND t.name = ''Settings'')
 BEGIN
     CREATE TABLE [' + @SchemaName + '].[Settings] (
-        SettingKey   NVARCHAR(100)    NOT NULL PRIMARY KEY,
-        SettingValue NVARCHAR(MAX)    NOT NULL,
-        UpdatedAt    DATETIME2        NOT NULL DEFAULT SYSUTCDATETIME(),
-        UpdatedBy    UNIQUEIDENTIFIER NULL
+        [SettingKey]   NVARCHAR(100)    NOT NULL PRIMARY KEY,
+        [SettingValue] NVARCHAR(MAX)    NOT NULL,
+        [UpdatedAt]    DATETIME2        NOT NULL DEFAULT SYSUTCDATETIME(),
+        [UpdatedBy]    UNIQUEIDENTIFIER NULL
     );
 END
 ';

--- a/backend/app/sql/spDeployCoreSchema.sql
+++ b/backend/app/sql/spDeployCoreSchema.sql
@@ -265,6 +265,26 @@ END
 ';
 
 -----------------------------------------
+-- SETTINGS
+-- Generic key/value table for application settings (e.g. SMTP config).
+-- Values are JSON-encoded text. Not system-versioned: rows are intentionally
+-- mutable in place; for an audit trail, audit at the route layer.
+-----------------------------------------
+SET @sql += '
+IF NOT EXISTS (SELECT 1 FROM sys.tables t
+               JOIN sys.schemas s ON t.schema_id = s.schema_id
+               WHERE s.name = ''' + @SchemaName + ''' AND t.name = ''Settings'')
+BEGIN
+    CREATE TABLE [' + @SchemaName + '].[Settings] (
+        SettingKey   NVARCHAR(100)    NOT NULL PRIMARY KEY,
+        SettingValue NVARCHAR(MAX)    NOT NULL,
+        UpdatedAt    DATETIME2        NOT NULL DEFAULT SYSUTCDATETIME(),
+        UpdatedBy    UNIQUEIDENTIFIER NULL
+    );
+END
+';
+
+-----------------------------------------
 -- Seed Data for Roles and Permissions
 -----------------------------------------
 SET @sql += '

--- a/backend/app/utils/connection_crypto.py
+++ b/backend/app/utils/connection_crypto.py
@@ -33,6 +33,30 @@ def encrypt_credentials(backend: CoreBackend, credentials: dict) -> str:
     return f.encrypt(json.dumps(credentials).encode("utf-8")).decode("utf-8")
 
 
+def encrypt_value(backend: CoreBackend, value: str) -> str:
+    """Encrypt a single string value with the CONNECTION_KEY Fernet key.
+
+    Used for opaque secrets (e.g. SMTP password) that don't fit the dict-shaped
+    `encrypt_credentials` helper. Reuses CONNECTION_KEY rather than introducing a
+    second key — see project_query_scheduling_pr2_handoff.
+    """
+    f = _get_fernet(backend)
+    return f.encrypt(value.encode("utf-8")).decode("utf-8")
+
+
+def decrypt_value(backend: CoreBackend, token: str) -> str:
+    """Decrypt a single string value previously written by `encrypt_value`."""
+    f = _get_fernet(backend)
+    try:
+        return f.decrypt(token.encode("utf-8")).decode("utf-8")
+    except InvalidToken:
+        logger.error("[connection_crypto] Failed to decrypt opaque secret — token corrupt or wrong key")
+        raise HTTPException(
+            status_code=500,
+            detail="Server configuration error: could not decrypt stored secret",
+        )
+
+
 def decrypt_credentials(backend: CoreBackend, token: str) -> dict:
     """Decrypt a stored Fernet token and return the credentials dict."""
     f = _get_fernet(backend)

--- a/backend/app/utils/email_sender.py
+++ b/backend/app/utils/email_sender.py
@@ -6,6 +6,7 @@
 
 import logging
 import smtplib
+import ssl
 from email.message import EmailMessage
 from typing import Literal
 
@@ -49,11 +50,18 @@ def send_email(
     body: str,
     attachment_bytes: bytes | None = None,
     attachment_filename: str | None = None,
+    verify_ssl: bool = True,
 ) -> None:
     """Send a single email synchronously. Raises EmailSendError on failure.
 
     Uses SMTP_SSL for tls_mode='tls', SMTP+STARTTLS for 'starttls', plain SMTP
     for 'none'. Authenticates only if both username and password are provided.
+
+    `verify_ssl` controls TLS certificate verification for both SMTP_SSL and
+    STARTTLS modes. Defaults to True (verify the server certificate against
+    the system trust store). Set to False for self-signed internal SMTP relays
+    — common in self-hosted deployments — but be aware this disables hostname
+    and certificate validation entirely. Has no effect when tls_mode='none'.
     """
     if not to:
         raise EmailSendError("At least one recipient required")
@@ -75,10 +83,16 @@ def send_email(
             filename=attachment_filename,
         )
 
+    if verify_ssl:
+        ssl_context = ssl.create_default_context()
+    else:
+        ssl_context = ssl.create_default_context()
+        ssl_context.check_hostname = False
+        ssl_context.verify_mode = ssl.CERT_NONE
+
     try:
         if tls_mode == "tls":
-            smtp_cls = smtplib.SMTP_SSL
-            with smtp_cls(host, port, timeout=15) as client:
+            with smtplib.SMTP_SSL(host, port, timeout=15, context=ssl_context) as client:
                 if username and password:
                     client.login(username, password)
                 client.send_message(msg)
@@ -86,7 +100,7 @@ def send_email(
             with smtplib.SMTP(host, port, timeout=15) as client:
                 client.ehlo()
                 if tls_mode == "starttls":
-                    client.starttls()
+                    client.starttls(context=ssl_context)
                     client.ehlo()
                 if username and password:
                     client.login(username, password)

--- a/backend/app/utils/email_sender.py
+++ b/backend/app/utils/email_sender.py
@@ -111,6 +111,12 @@ def send_email(
                         )
                     client.login(username, password)
                 client.send_message(msg)
+    except smtplib.SMTPAuthenticationError as e:
+        # The server's auth response can echo the username back. Log the
+        # full response for the operator (audit trail) but surface only the
+        # SMTP code in the API/UI to avoid round-tripping credentials.
+        logger.warning("[email_sender] SMTP auth failed: %s", e)
+        raise EmailSendError(f"SMTP authentication failed (code {getattr(e, 'smtp_code', '?')})")
     except (smtplib.SMTPException, OSError) as e:
         logger.warning("[email_sender] Send failed: %s", e)
         raise EmailSendError(str(e))

--- a/backend/app/utils/email_sender.py
+++ b/backend/app/utils/email_sender.py
@@ -83,10 +83,8 @@ def send_email(
             filename=attachment_filename,
         )
 
-    if verify_ssl:
-        ssl_context = ssl.create_default_context()
-    else:
-        ssl_context = ssl.create_default_context()
+    ssl_context = ssl.create_default_context()
+    if not verify_ssl:
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE
 

--- a/backend/app/utils/email_sender.py
+++ b/backend/app/utils/email_sender.py
@@ -1,0 +1,96 @@
+# app/utils/email_sender.py
+#
+# Thin wrapper around stdlib smtplib + email.message.EmailMessage.
+# All failures are normalised to EmailSendError so callers don't depend on
+# smtplib internals. No external dependencies.
+
+import logging
+import smtplib
+from email.message import EmailMessage
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+TlsMode = Literal["none", "starttls", "tls"]
+
+_CSV_MIME = ("text", "csv")
+_XLSX_MIME = (
+    "application",
+    "vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+)
+
+
+class EmailSendError(Exception):
+    """Raised when an email cannot be sent. Message is the underlying error."""
+
+
+def _attachment_mime(filename: str) -> tuple[str, str]:
+    lower = filename.lower()
+    if lower.endswith(".csv"):
+        return _CSV_MIME
+    if lower.endswith(".xlsx"):
+        return _XLSX_MIME
+    # Generic fallback — caller should normally use one of the two above.
+    return ("application", "octet-stream")
+
+
+def send_email(
+    *,
+    host: str,
+    port: int,
+    tls_mode: TlsMode,
+    username: str | None,
+    password: str | None,
+    from_address: str,
+    from_name: str | None,
+    reply_to: str | None,
+    to: list[str],
+    subject: str,
+    body: str,
+    attachment_bytes: bytes | None = None,
+    attachment_filename: str | None = None,
+) -> None:
+    """Send a single email synchronously. Raises EmailSendError on failure.
+
+    Uses SMTP_SSL for tls_mode='tls', SMTP+STARTTLS for 'starttls', plain SMTP
+    for 'none'. Authenticates only if both username and password are provided.
+    """
+    if not to:
+        raise EmailSendError("At least one recipient required")
+
+    msg = EmailMessage()
+    msg["From"] = f"{from_name} <{from_address}>" if from_name else from_address
+    msg["To"] = ", ".join(to)
+    msg["Subject"] = subject
+    if reply_to:
+        msg["Reply-To"] = reply_to
+    msg.set_content(body)
+
+    if attachment_bytes is not None and attachment_filename:
+        maintype, subtype = _attachment_mime(attachment_filename)
+        msg.add_attachment(
+            attachment_bytes,
+            maintype=maintype,
+            subtype=subtype,
+            filename=attachment_filename,
+        )
+
+    try:
+        if tls_mode == "tls":
+            smtp_cls = smtplib.SMTP_SSL
+            with smtp_cls(host, port, timeout=15) as client:
+                if username and password:
+                    client.login(username, password)
+                client.send_message(msg)
+        else:
+            with smtplib.SMTP(host, port, timeout=15) as client:
+                client.ehlo()
+                if tls_mode == "starttls":
+                    client.starttls()
+                    client.ehlo()
+                if username and password:
+                    client.login(username, password)
+                client.send_message(msg)
+    except (smtplib.SMTPException, OSError) as e:
+        logger.warning("[email_sender] Send failed: %s", e)
+        raise EmailSendError(str(e))

--- a/backend/app/utils/email_sender.py
+++ b/backend/app/utils/email_sender.py
@@ -14,12 +14,6 @@ logger = logging.getLogger(__name__)
 
 TlsMode = Literal["none", "starttls", "tls"]
 
-_CSV_MIME = ("text", "csv")
-_XLSX_MIME = (
-    "application",
-    "vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-)
-
 
 class EmailSendError(Exception):
     """Raised when an email cannot be sent. Message is the underlying error."""
@@ -28,9 +22,9 @@ class EmailSendError(Exception):
 def _attachment_mime(filename: str) -> tuple[str, str]:
     lower = filename.lower()
     if lower.endswith(".csv"):
-        return _CSV_MIME
+        return ("text", "csv")
     if lower.endswith(".xlsx"):
-        return _XLSX_MIME
+        return ("application", "vnd.openxmlformats-officedocument.spreadsheetml.sheet")
     # Generic fallback — caller should normally use one of the two above.
     return ("application", "octet-stream")
 

--- a/backend/app/utils/email_sender.py
+++ b/backend/app/utils/email_sender.py
@@ -95,6 +95,20 @@ def send_email(
                     client.starttls(context=ssl_context)
                     client.ehlo()
                 if username and password:
+                    if tls_mode == "none":
+                        # smtplib.login negotiates the strongest mechanism the
+                        # server advertises, which on a non-TLS connection may
+                        # be PLAIN or LOGIN — i.e. credentials in cleartext.
+                        # Some self-hosted relays genuinely require auth over
+                        # plaintext on a trusted network, so we don't refuse,
+                        # but we surface a clear warning so the operator
+                        # cannot do this by accident.
+                        logger.warning(
+                            "[email_sender] Authenticating to %s:%s with tls_mode='none' — "
+                            "credentials will be transmitted unencrypted",
+                            host,
+                            port,
+                        )
                     client.login(username, password)
                 client.send_message(msg)
     except (smtplib.SMTPException, OSError) as e:

--- a/backend/app/utils/email_sender.py
+++ b/backend/app/utils/email_sender.py
@@ -112,9 +112,12 @@ def send_email(
                     client.login(username, password)
                 client.send_message(msg)
     except smtplib.SMTPAuthenticationError as e:
-        # The server's auth response can echo the username back. Log the
-        # full response for the operator (audit trail) but surface only the
-        # SMTP code in the API/UI to avoid round-tripping credentials.
+        # IMPORTANT: this handler MUST precede the generic SMTPException
+        # catch below — SMTPAuthenticationError is a subclass and would
+        # otherwise fall through and leak the raw server response (which
+        # may echo the username) into the API surface.
+        # The full response is logged for the operator audit trail; only
+        # the SMTP code is surfaced to the UI.
         logger.warning("[email_sender] SMTP auth failed: %s", e)
         raise EmailSendError(f"SMTP authentication failed (code {getattr(e, 'smtp_code', '?')})")
     except (smtplib.SMTPException, OSError) as e:

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -13,6 +13,7 @@ import DataBrowserPage from './pages/DataBrowserPage';
 import UsersPage from './pages/UsersPage';
 import SavedQueriesPage from './pages/SavedQueriesPage';
 import AuditLogPage from './pages/AuditLogPage';
+import SmtpSettingsPage from './pages/SmtpSettingsPage';
 import ProfilePage from './pages/ProfilePage';
 import Layout from './components/Layout';
 import AppShell from './components/AppShell';
@@ -155,6 +156,17 @@ export default function App() {
             <RequireAuth>
               <AppShell>
                 <AuditLogPage />
+              </AppShell>
+            </RequireAuth>
+          }
+        />
+
+        <Route
+          path="/settings/smtp"
+          element={
+            <RequireAuth>
+              <AppShell>
+                <SmtpSettingsPage />
               </AppShell>
             </RequireAuth>
           }

--- a/frontend/src/components/Sidebar.jsx
+++ b/frontend/src/components/Sidebar.jsx
@@ -1,6 +1,9 @@
 // src/components/Sidebar.jsx
-import React, { useState } from 'react';
+import React, { useContext, useState } from 'react';
 import { NavLink } from 'react-router-dom';
+import { UserContext } from '../context/UserContext';
+
+const ADMIN_ROLES = new Set(['Admin', 'SystemAdmin']);
 
 const NAV_ITEMS = [
   {
@@ -80,6 +83,27 @@ const NAV_ITEMS = [
     implemented: true,
   },
   {
+    label: 'SMTP Settings',
+    path: '/settings/smtp',
+    icon: (
+      <svg
+        className="w-5 h-5 shrink-0"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth={1.75}
+        viewBox="0 0 24 24"
+      >
+        <path
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          d="M3 8l9 6 9-6M5 19h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v10a2 2 0 002 2z"
+        />
+      </svg>
+    ),
+    implemented: true,
+    adminOnly: true,
+  },
+  {
     label: 'Audit Log',
     path: '/audit',
     icon: (
@@ -108,6 +132,9 @@ const DISABLED_ITEM = 'text-gray-600 cursor-not-allowed select-none';
 
 export default function Sidebar() {
   const [collapsed, setCollapsed] = useState(false);
+  const user = useContext(UserContext);
+  const isAdmin = !!user?.roles?.some((r) => ADMIN_ROLES.has(r));
+  const visibleItems = NAV_ITEMS.filter((item) => !item.adminOnly || isAdmin);
 
   return (
     <aside
@@ -147,7 +174,7 @@ export default function Sidebar() {
 
       {/* Nav items */}
       <nav className="flex-1 py-3 space-y-0.5 overflow-y-auto">
-        {NAV_ITEMS.map((item) => {
+        {visibleItems.map((item) => {
           if (!item.implemented) {
             return (
               <div

--- a/frontend/src/pages/SmtpSettingsPage.jsx
+++ b/frontend/src/pages/SmtpSettingsPage.jsx
@@ -121,8 +121,8 @@ export default function SmtpSettingsPage() {
     );
   }
 
-  async function handleSave(e) {
-    e.preventDefault();
+  async function handleSave(event) {
+    event.preventDefault();
     setError(null);
     setSavedMsg(null);
     const portNum = Number(form.port);
@@ -151,8 +151,8 @@ export default function SmtpSettingsPage() {
       const data = await res.json();
       setPasswordSet(!!data.password_set);
       setSavedMsg('Settings saved.');
-    } catch (e) {
-      setError(e.message);
+    } catch (err) {
+      setError(err.message);
     } finally {
       setSaving(false);
     }
@@ -172,8 +172,8 @@ export default function SmtpSettingsPage() {
       setPasswordInput('');
       setPasswordSet(true);
       setSavedMsg('Password updated.');
-    } catch (e) {
-      setError(e.message);
+    } catch (err) {
+      setError(err.message);
     } finally {
       setPasswordSaving(false);
     }
@@ -194,8 +194,8 @@ export default function SmtpSettingsPage() {
       } else {
         setTestResult(body);
       }
-    } catch (e) {
-      setTestResult({ ok: false, error: e.message });
+    } catch (err) {
+      setTestResult({ ok: false, error: err.message });
     } finally {
       setTestSending(false);
     }

--- a/frontend/src/pages/SmtpSettingsPage.jsx
+++ b/frontend/src/pages/SmtpSettingsPage.jsx
@@ -1,0 +1,451 @@
+// src/pages/SmtpSettingsPage.jsx
+//
+// Admin-only SMTP configuration page. Lets an admin configure outbound mail
+// settings, set/replace the SMTP password, and send a test email.
+//
+// Role gating happens both here (UI) and on every backend route. The backend
+// is the source of truth — this page assumes any failure to fetch is fatal.
+
+import React, { useContext, useEffect, useState } from 'react';
+import { Navigate } from 'react-router-dom';
+import { UserContext } from '../context/UserContext';
+import { authHeader } from '../utils/auth';
+
+const ADMIN_ROLES = new Set(['Admin', 'SystemAdmin']);
+
+function hasAdminRole(user) {
+  if (!user?.roles) return false;
+  return user.roles.some((r) => ADMIN_ROLES.has(r));
+}
+
+const EMPTY_FORM = {
+  host: '',
+  port: 587,
+  tls_mode: 'starttls',
+  username: '',
+  from_address: '',
+  from_name: '',
+  reply_to_address: '',
+  allowlist_enabled: false,
+  allowed_domains: [],
+};
+
+export default function SmtpSettingsPage() {
+  const user = useContext(UserContext);
+  const isAdmin = hasAdminRole(user);
+
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState(null);
+  const [form, setForm] = useState(EMPTY_FORM);
+  const [passwordSet, setPasswordSet] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [savedMsg, setSavedMsg] = useState(null);
+
+  const [passwordInput, setPasswordInput] = useState('');
+  const [passwordSaving, setPasswordSaving] = useState(false);
+
+  const [domainDraft, setDomainDraft] = useState('');
+
+  const [testOpen, setTestOpen] = useState(false);
+  const [testTo, setTestTo] = useState('');
+  const [testResult, setTestResult] = useState(null);
+  const [testSending, setTestSending] = useState(false);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    fetch('/api/settings/smtp', { headers: authHeader() })
+      .then((r) => {
+        if (!r.ok) throw new Error(`HTTP ${r.status}`);
+        return r.json();
+      })
+      .then((data) => {
+        setForm({
+          host: data.host ?? '',
+          port: data.port ?? 587,
+          tls_mode: data.tls_mode ?? 'starttls',
+          username: data.username ?? '',
+          from_address: data.from_address ?? '',
+          from_name: data.from_name ?? '',
+          reply_to_address: data.reply_to_address ?? '',
+          allowlist_enabled: !!data.allowlist_enabled,
+          allowed_domains: data.allowed_domains ?? [],
+        });
+        setPasswordSet(!!data.password_set);
+      })
+      .catch((e) => setError(e.message))
+      .finally(() => setLoading(false));
+  }, [isAdmin]);
+
+  if (!isAdmin) return <Navigate to="/dashboard" replace />;
+
+  function update(field, value) {
+    setForm((prev) => ({ ...prev, [field]: value }));
+    setSavedMsg(null);
+  }
+
+  function addDomain() {
+    const d = domainDraft.trim().toLowerCase();
+    if (!d || form.allowed_domains.includes(d)) {
+      setDomainDraft('');
+      return;
+    }
+    update('allowed_domains', [...form.allowed_domains, d]);
+    setDomainDraft('');
+  }
+
+  function removeDomain(d) {
+    update(
+      'allowed_domains',
+      form.allowed_domains.filter((x) => x !== d)
+    );
+  }
+
+  async function handleSave(e) {
+    e.preventDefault();
+    setSaving(true);
+    setError(null);
+    setSavedMsg(null);
+    try {
+      const payload = {
+        ...form,
+        port: Number(form.port),
+        username: form.username || null,
+        from_name: form.from_name || null,
+        reply_to_address: form.reply_to_address || null,
+      };
+      const res = await fetch('/api/settings/smtp', {
+        method: 'PUT',
+        headers: { ...authHeader(), 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.detail ? JSON.stringify(body.detail) : `HTTP ${res.status}`);
+      }
+      const data = await res.json();
+      setPasswordSet(!!data.password_set);
+      setSavedMsg('Settings saved.');
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function handlePasswordSave() {
+    if (!passwordInput) return;
+    setPasswordSaving(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/settings/smtp/password', {
+        method: 'PUT',
+        headers: { ...authHeader(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ password: passwordInput }),
+      });
+      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      setPasswordInput('');
+      setPasswordSet(true);
+      setSavedMsg('Password updated.');
+    } catch (e) {
+      setError(e.message);
+    } finally {
+      setPasswordSaving(false);
+    }
+  }
+
+  async function handleSendTest() {
+    setTestSending(true);
+    setTestResult(null);
+    try {
+      const res = await fetch('/api/settings/smtp/test', {
+        method: 'POST',
+        headers: { ...authHeader(), 'Content-Type': 'application/json' },
+        body: JSON.stringify({ to: testTo }),
+      });
+      const body = await res.json().catch(() => ({}));
+      if (!res.ok) {
+        setTestResult({ ok: false, error: body.detail || `HTTP ${res.status}` });
+      } else {
+        setTestResult(body);
+      }
+    } catch (e) {
+      setTestResult({ ok: false, error: e.message });
+    } finally {
+      setTestSending(false);
+    }
+  }
+
+  if (loading) return <div className="p-6 text-sm text-gray-500">Loading SMTP settings…</div>;
+
+  return (
+    <div className="p-6 max-w-3xl">
+      <h1 className="text-xl font-semibold mb-1">SMTP Settings</h1>
+      <p className="text-sm text-gray-500 mb-6">
+        Outbound email server used for scheduled query deliveries and test messages.
+      </p>
+
+      {error && (
+        <div className="mb-4 p-3 bg-red-50 border border-red-200 text-red-700 text-sm rounded">
+          {error}
+        </div>
+      )}
+      {savedMsg && (
+        <div className="mb-4 p-3 bg-green-50 border border-green-200 text-green-700 text-sm rounded">
+          {savedMsg}
+        </div>
+      )}
+
+      <form onSubmit={handleSave} className="space-y-4 bg-white border rounded p-5">
+        <div className="grid grid-cols-2 gap-4">
+          <label className="block text-sm">
+            <span className="text-gray-700">Host</span>
+            <input
+              type="text"
+              required
+              value={form.host}
+              onChange={(e) => update('host', e.target.value)}
+              className="mt-1 w-full border rounded px-2 py-1.5"
+              placeholder="smtp.example.com"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-gray-700">Port</span>
+            <input
+              type="number"
+              required
+              min={1}
+              max={65535}
+              value={form.port}
+              onChange={(e) => update('port', e.target.value)}
+              className="mt-1 w-full border rounded px-2 py-1.5"
+            />
+          </label>
+        </div>
+
+        <fieldset className="text-sm">
+          <legend className="text-gray-700 mb-1">TLS mode</legend>
+          <div className="flex gap-4">
+            {['none', 'starttls', 'tls'].map((mode) => (
+              <label key={mode} className="flex items-center gap-1">
+                <input
+                  type="radio"
+                  name="tls_mode"
+                  value={mode}
+                  checked={form.tls_mode === mode}
+                  onChange={() => update('tls_mode', mode)}
+                />
+                {mode === 'none' ? 'None' : mode === 'starttls' ? 'STARTTLS' : 'TLS (SSL)'}
+              </label>
+            ))}
+          </div>
+        </fieldset>
+
+        <label className="block text-sm">
+          <span className="text-gray-700">Username (optional)</span>
+          <input
+            type="text"
+            value={form.username}
+            onChange={(e) => update('username', e.target.value)}
+            className="mt-1 w-full border rounded px-2 py-1.5"
+          />
+        </label>
+
+        <div className="grid grid-cols-2 gap-4">
+          <label className="block text-sm">
+            <span className="text-gray-700">From address</span>
+            <input
+              type="email"
+              required
+              value={form.from_address}
+              onChange={(e) => update('from_address', e.target.value)}
+              className="mt-1 w-full border rounded px-2 py-1.5"
+              placeholder="reports@example.com"
+            />
+          </label>
+          <label className="block text-sm">
+            <span className="text-gray-700">From display name (optional)</span>
+            <input
+              type="text"
+              value={form.from_name}
+              onChange={(e) => update('from_name', e.target.value)}
+              className="mt-1 w-full border rounded px-2 py-1.5"
+              placeholder="admin-it Reports"
+            />
+          </label>
+        </div>
+
+        <label className="block text-sm">
+          <span className="text-gray-700">Reply-To address (optional)</span>
+          <input
+            type="email"
+            value={form.reply_to_address}
+            onChange={(e) => update('reply_to_address', e.target.value)}
+            className="mt-1 w-full border rounded px-2 py-1.5"
+          />
+        </label>
+
+        <div className="border-t pt-4">
+          <label className="flex items-center gap-2 text-sm">
+            <input
+              type="checkbox"
+              checked={form.allowlist_enabled}
+              onChange={(e) => update('allowlist_enabled', e.target.checked)}
+            />
+            <span className="text-gray-700">Restrict outbound mail to allowed domains</span>
+          </label>
+
+          {form.allowlist_enabled && (
+            <div className="mt-3">
+              <div className="flex gap-2">
+                <input
+                  type="text"
+                  value={domainDraft}
+                  onChange={(e) => setDomainDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      e.preventDefault();
+                      addDomain();
+                    }
+                  }}
+                  className="flex-1 border rounded px-2 py-1.5 text-sm"
+                  placeholder="example.com"
+                />
+                <button
+                  type="button"
+                  onClick={addDomain}
+                  className="px-3 py-1.5 bg-gray-200 text-sm rounded hover:bg-gray-300"
+                >
+                  Add
+                </button>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-2">
+                {form.allowed_domains.map((d) => (
+                  <span
+                    key={d}
+                    className="inline-flex items-center gap-1 bg-gray-100 border rounded px-2 py-0.5 text-xs"
+                  >
+                    {d}
+                    <button
+                      type="button"
+                      onClick={() => removeDomain(d)}
+                      className="text-gray-500 hover:text-red-600"
+                      aria-label={`Remove ${d}`}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
+
+        <p className="text-xs text-gray-500 border-l-2 border-gray-300 pl-3">
+          If you&apos;re sending to recipients outside your organisation, ensure your DNS has SPF
+          and DKIM records authorising this SMTP host to send as the From address, or recipients may
+          filter messages as spam.
+        </p>
+
+        <div className="flex justify-end gap-2 pt-2">
+          <button
+            type="button"
+            onClick={() => setTestOpen(true)}
+            className="px-3 py-1.5 border rounded text-sm hover:bg-gray-50"
+          >
+            Send test email
+          </button>
+          <button
+            type="submit"
+            disabled={saving}
+            className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : 'Save settings'}
+          </button>
+        </div>
+      </form>
+
+      <div className="mt-6 bg-white border rounded p-5">
+        <h2 className="text-base font-semibold">SMTP password</h2>
+        <p className="text-xs text-gray-500 mb-3">
+          {passwordSet
+            ? 'A password is currently set. Enter a new one to replace it.'
+            : 'No password is set. Some servers require one for authentication.'}
+        </p>
+        <div className="flex gap-2">
+          <input
+            type="password"
+            value={passwordInput}
+            onChange={(e) => setPasswordInput(e.target.value)}
+            className="flex-1 border rounded px-2 py-1.5 text-sm"
+            placeholder="New password"
+            autoComplete="new-password"
+          />
+          <button
+            type="button"
+            onClick={handlePasswordSave}
+            disabled={passwordSaving || !passwordInput}
+            className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50"
+          >
+            {passwordSaving ? 'Saving…' : 'Update password'}
+          </button>
+        </div>
+        {passwordSet && (
+          <span className="inline-block mt-2 text-xs bg-green-100 text-green-800 px-2 py-0.5 rounded">
+            Password is set
+          </span>
+        )}
+      </div>
+
+      {testOpen && (
+        <div className="fixed inset-0 bg-black/30 flex items-center justify-center z-50">
+          <div className="bg-white rounded shadow-lg p-5 w-full max-w-md">
+            <h3 className="text-base font-semibold mb-2">Send test email</h3>
+            <p className="text-xs text-gray-500 mb-3">
+              Sends a one-line test message using the currently saved settings (not the unsaved form
+              values).
+            </p>
+            <input
+              type="email"
+              value={testTo}
+              onChange={(e) => setTestTo(e.target.value)}
+              className="w-full border rounded px-2 py-1.5 text-sm"
+              placeholder="recipient@example.com"
+            />
+            {testResult && (
+              <div
+                className={`mt-3 p-2 text-xs rounded ${
+                  testResult.ok
+                    ? 'bg-green-50 text-green-800 border border-green-200'
+                    : 'bg-red-50 text-red-800 border border-red-200'
+                }`}
+              >
+                {testResult.ok ? 'Test email sent successfully.' : `Failed: ${testResult.error}`}
+              </div>
+            )}
+            <div className="mt-4 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  setTestOpen(false);
+                  setTestResult(null);
+                  setTestTo('');
+                }}
+                className="px-3 py-1.5 border rounded text-sm hover:bg-gray-50"
+              >
+                Close
+              </button>
+              <button
+                type="button"
+                disabled={testSending || !testTo}
+                onClick={handleSendTest}
+                className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50"
+              >
+                {testSending ? 'Sending…' : 'Send'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/pages/SmtpSettingsPage.jsx
+++ b/frontend/src/pages/SmtpSettingsPage.jsx
@@ -83,7 +83,7 @@ export default function SmtpSettingsPage() {
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [isAdmin, user]);
+  }, [user, isAdmin]);
 
   if (user === null) return <div className="p-6 text-sm text-gray-500">Loading…</div>;
   if (!isAdmin) return <Navigate to="/dashboard" replace />;
@@ -159,7 +159,10 @@ export default function SmtpSettingsPage() {
   }
 
   async function handlePasswordSave() {
-    if (!passwordInput) return;
+    if (!passwordInput.trim()) {
+      setError('Password must not be empty or whitespace-only.');
+      return;
+    }
     setPasswordSaving(true);
     setError(null);
     try {

--- a/frontend/src/pages/SmtpSettingsPage.jsx
+++ b/frontend/src/pages/SmtpSettingsPage.jsx
@@ -28,6 +28,7 @@ const EMPTY_FORM = {
   reply_to_address: '',
   allowlist_enabled: false,
   allowed_domains: [],
+  verify_ssl: true,
 };
 
 export default function SmtpSettingsPage() {
@@ -52,7 +53,14 @@ export default function SmtpSettingsPage() {
   const [testSending, setTestSending] = useState(false);
 
   useEffect(() => {
-    if (!isAdmin) return;
+    // Wait until UserContext has populated. `user === null` means the
+    // /auth/me lookup in App.jsx hasn't returned yet — don't redirect a
+    // legitimate admin to /dashboard before their roles arrive.
+    if (user === null) return;
+    if (!isAdmin) {
+      setLoading(false);
+      return;
+    }
     fetch('/api/settings/smtp', { headers: authHeader() })
       .then((r) => {
         if (!r.ok) throw new Error(`HTTP ${r.status}`);
@@ -69,13 +77,15 @@ export default function SmtpSettingsPage() {
           reply_to_address: data.reply_to_address ?? '',
           allowlist_enabled: !!data.allowlist_enabled,
           allowed_domains: data.allowed_domains ?? [],
+          verify_ssl: data.verify_ssl !== false,
         });
         setPasswordSet(!!data.password_set);
       })
       .catch((e) => setError(e.message))
       .finally(() => setLoading(false));
-  }, [isAdmin]);
+  }, [isAdmin, user]);
 
+  if (user === null) return <div className="p-6 text-sm text-gray-500">Loading…</div>;
   if (!isAdmin) return <Navigate to="/dashboard" replace />;
 
   function update(field, value) {
@@ -216,7 +226,7 @@ export default function SmtpSettingsPage() {
               min={1}
               max={65535}
               value={form.port}
-              onChange={(e) => update('port', e.target.value)}
+              onChange={(e) => update('port', e.target.value === '' ? '' : Number(e.target.value))}
               className="mt-1 w-full border rounded px-2 py-1.5"
             />
           </label>
@@ -239,6 +249,25 @@ export default function SmtpSettingsPage() {
             ))}
           </div>
         </fieldset>
+
+        <label
+          className={`flex items-start gap-2 text-sm ${form.tls_mode === 'none' ? 'opacity-50' : ''}`}
+        >
+          <input
+            type="checkbox"
+            checked={form.verify_ssl}
+            disabled={form.tls_mode === 'none'}
+            onChange={(e) => update('verify_ssl', e.target.checked)}
+            className="mt-0.5"
+          />
+          <span className="text-gray-700">
+            Verify TLS certificate
+            <span className="block text-xs text-gray-500">
+              Disable only for self-signed internal SMTP relays. Disabling skips hostname and
+              certificate validation entirely.
+            </span>
+          </span>
+        </label>
 
         <label className="block text-sm">
           <span className="text-gray-700">Username (optional)</span>

--- a/frontend/src/pages/SmtpSettingsPage.jsx
+++ b/frontend/src/pages/SmtpSettingsPage.jsx
@@ -95,10 +95,21 @@ export default function SmtpSettingsPage() {
 
   function addDomain() {
     const d = domainDraft.trim().toLowerCase();
-    if (!d || form.allowed_domains.includes(d)) {
+    if (!d) {
       setDomainDraft('');
       return;
     }
+    // Mirror the backend regex so the user gets immediate feedback rather
+    // than a 422 from Pydantic at save time.
+    if (!/^[a-z0-9.-]+\.[a-z]{2,}$/.test(d)) {
+      setError(`Invalid domain: ${d}`);
+      return;
+    }
+    if (form.allowed_domains.includes(d)) {
+      setDomainDraft('');
+      return;
+    }
+    setError(null);
     update('allowed_domains', [...form.allowed_domains, d]);
     setDomainDraft('');
   }
@@ -112,13 +123,18 @@ export default function SmtpSettingsPage() {
 
   async function handleSave(e) {
     e.preventDefault();
-    setSaving(true);
     setError(null);
     setSavedMsg(null);
+    const portNum = Number(form.port);
+    if (!Number.isFinite(portNum) || portNum < 1 || portNum > 65535) {
+      setError('Port must be a number between 1 and 65535.');
+      return;
+    }
+    setSaving(true);
     try {
       const payload = {
         ...form,
-        port: Number(form.port),
+        port: portNum,
         username: form.username || null,
         from_name: form.from_name || null,
         reply_to_address: form.reply_to_address || null,

--- a/frontend/src/pages/SmtpSettingsPage.jsx
+++ b/frontend/src/pages/SmtpSettingsPage.jsx
@@ -431,7 +431,7 @@ export default function SmtpSettingsPage() {
           <button
             type="button"
             onClick={handlePasswordSave}
-            disabled={passwordSaving || !passwordInput}
+            disabled={passwordSaving || !passwordInput.trim()}
             className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50"
           >
             {passwordSaving ? 'Saving…' : 'Update password'}
@@ -484,7 +484,7 @@ export default function SmtpSettingsPage() {
               </button>
               <button
                 type="button"
-                disabled={testSending || !testTo}
+                disabled={testSending || !testTo.trim()}
                 onClick={handleSendTest}
                 className="px-3 py-1.5 bg-blue-600 text-white text-sm rounded hover:bg-blue-700 disabled:opacity-50"
               >


### PR DESCRIPTION
## Summary

PR 2 of the query-scheduling plan (#140). Adds the outbound mail foundation so admins can configure SMTP and send test emails. **No scheduling logic in this PR** — that lands in PR 3.

## What's in this PR

**Backend**
- New `[adm].[Settings]` table (generic key/value, JSON-encoded values) added to **both** `spDeployCoreSchema.sql` and `deploy_core_schema_postgres.sql`, guarded by `IF NOT EXISTS` so re-running the deploy on existing installs is safe.
- New `encrypt_value` / `decrypt_value` helpers in `connection_crypto.py` reuse the existing `CONNECTION_KEY` Fernet key. **No separate `SMTP_KEY`** — agreed during planning.
- New `utils/email_sender.py` wraps stdlib `smtplib` (no new dependencies). All failures normalised to `EmailSendError`.
- New `routes/settings_routes.py` exposes four admin-only endpoints under `/api/settings/smtp`:
  - `GET /smtp` — current config + `password_set` boolean (never the password itself)
  - `PUT /smtp` — replace config
  - `PUT /smtp/password` — write-only password update
  - `POST /smtp/test` — send a test message; returns `{ok: true}` or `{ok: false, error: "..."}` with status 200 either way
- Router registered in `main.py`.

**Frontend**
- New `SmtpSettingsPage.jsx` with config form (host/port/TLS mode/username/from/reply-to), allowed-domains chip editor, write-only password panel, and a test-email modal. Plain `fetch` + `authHeader()`, no axios.
- New `/settings/smtp` route in `App.jsx`.
- `Sidebar.jsx` gains an admin-only "SMTP Settings" entry, gated via `UserContext`.

## Security model

- Every route uses `Depends(verify_token)` **and** an explicit `Admin`/`SystemAdmin` role check (authentication ≠ authorisation).
- All SQL identifiers go through `qi()` (bracket-quoted). All values use bind parameters.
- The `Settings` table is generic key/value, but the route layer constrains every key reaching the SQL template to a hardcoded `SMTP_SETTING_KEYS` allowlist — no caller-derived keys.
- The SMTP password is **never** returned by `GET`. Stored Fernet-encrypted in `[adm].[Secrets]` under `SecretType = 'SMTP_PASSWORD'` using the existing `CONNECTION_KEY`.
- `PUT /smtp` validates with Pydantic (`Literal[...]` for `tls_mode`, length bounds on every field, regex on email + domain inputs).
- The frontend role check is UI convenience only — backend enforcement is the source of truth.

## Conscious tradeoffs

- **Tests deferred.** Backend has no `tests/` directory yet; same deviation as #144. To be addressed in a dedicated test-bootstrap ticket.
- **Email validation is regex, not `EmailStr`.** `email-validator` is not in `requirements.txt` and the SMTP server is the real source of truth for deliverability. A simple `^[^@\s]+@[^@\s]+\.[^@\s]+$` check is sufficient at the boundary.
- **Sidebar nav, not a separate Header.** The plan referenced a `Header.jsx` that doesn't exist in this codebase — navigation lives in `Sidebar.jsx`. Added there with the existing role-gating pattern.

## Test plan

- [ ] Re-run the deploy script against an existing install — `Settings` table created without errors
- [ ] As a non-admin, hit each `/api/settings/smtp*` route → 403
- [ ] As admin, GET `/api/settings/smtp` on a fresh install → all `null`s, `password_set: false`
- [ ] PUT a full config, then GET → matches what was sent
- [ ] PUT password, GET → `password_set: true`, password not in response
- [ ] POST `/test` with valid creds against a real SMTP server → `{ok: true}`, message arrives
- [ ] POST `/test` with bad host → `{ok: false, error: "..."}` and status 200
- [ ] Sidebar shows "SMTP Settings" only for Admin/SystemAdmin

🤖 Generated with [Claude Code](https://claude.com/claude-code)